### PR TITLE
Add package.json for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "billforward-js",
+  "version": "1.0.0",
+  "description": "BillForward.js client for easy, gateway-agnostic card tokenization",
+  "main": "src/index.js",
+  "directories": {
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/billforward/billforward-js.git"
+  },
+  "keywords": [
+    "billforward"
+  ],
+  "author": "BillForward <support@billforward.net>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/billforward/billforward-js/issues"
+  },
+  "homepage": "https://github.com/billforward/billforward-js#readme"
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "billforward-js",
   "version": "1.0.0",
   "description": "BillForward.js client for easy, gateway-agnostic card tokenization",
-  "main": "src/index.js",
+  "main": "src/billforward.js",
   "directories": {
     "example": "examples"
   },


### PR DESCRIPTION
I would like to be able to consume this library from [npm](https://www.npmjs.com).

This PR adds a `package.json` file to the repo which points to the `src/index.js` file as the entry point.

Would you mind merging this and publishing on npm? Here is the docs on how to do it: https://docs.npmjs.com/getting-started/publishing-npm-packages
