### PR TITLE
Add UMD for AMD/Common.js/Globals

### DIFF
--- a/src/billforward.js
+++ b/src/billforward.js
@@ -13,7 +13,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -73,7 +73,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -99,7 +99,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -133,7 +133,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -171,7 +171,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -197,7 +197,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -229,7 +229,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -265,7 +265,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -289,7 +289,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -325,7 +325,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -397,7 +397,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -442,7 +442,7 @@
              - Tip: To check for a range of IE versions, use if (!IE || IE < MAX_VERSION)...
             */
 
-            var IE = (function() { 
+            var IE = (function() {
                 if (document.documentMode) {
                     return document.documentMode;
                 } else {
@@ -478,7 +478,7 @@
                 });
                 return;
             }
-            
+
             $.ajax(ajaxObj)
             .success(function() {
                 self.preAuthSuccessHandler.apply(self, arguments);
@@ -505,7 +505,7 @@
                 });
                 return;
             }
-            
+
             $.ajax(ajaxObj)
             .success(function() {
                 self.authCaptureSuccessHandler.apply(self, arguments);
@@ -789,7 +789,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -830,7 +830,7 @@
                     self.startAuthCapture(self.preAuthResponsePayload);
                 };
 
-                this.submitDancer.doWhenReady(deferredTransaction);   
+                this.submitDancer.doWhenReady(deferredTransaction);
             // }
         };
 
@@ -877,7 +877,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -911,7 +911,7 @@
                 stripePublishableKey = data.results[0].publicKey;
                 if (!data.results[0].publicKey) {
                     failed = true;
-                }   
+                }
             } catch (e){
                 failed = true;
             }
@@ -931,7 +931,7 @@
 
             var stripePublishableKey = data.results[0].publicKey;
             Stripe.setPublishableKey(stripePublishableKey);
-            
+
             var tokenInfo = {};
 
             var resolvedValues = (function(mappings) {
@@ -954,7 +954,7 @@
             var setKeyToVal = function(key, value) {
                 tokenInfo[TheClass.mappings[key]] = value;
             };
-            
+
             for (var i in TheClass.mappings) {
                 var mapping = TheClass.mappings[i];
                 var valueFromForm = resolvedValues[i];
@@ -962,7 +962,7 @@
                 var doDefault = function() {
                     setKeyToVal(i, valueFromForm);
                 };
-                
+
                 if (valueFromForm) {
                     switch (i) {
                         case 'exp-date':
@@ -1067,7 +1067,7 @@
 
                 // add BF-only attributes here
                 var additional = {};
-            
+
                 for (var i in TheClass.bfBypass) {
                     var mapping = TheClass.bfBypass[i];
                     var valueFromForm;
@@ -1082,7 +1082,7 @@
                             valueFromForm = valueFromForm && valueFromForm !== "false" ? true : false;
                             break;
                     }
-                    
+
                     if (valueFromForm) {
                         additional[TheClass.bfBypass[i]] = valueFromForm;
                     }
@@ -1135,7 +1135,7 @@
             'name-last': 'lastName'
             //'company': 'company',
         };
-        
+
         // these, if present, will be thrown straight into BF authCapture request.
         TheClass.bfBypass = {
             'company-name': 'companyName',
@@ -1150,7 +1150,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -1210,7 +1210,7 @@
                         resolvedEnvironment = BraintreeData.environments.sandbox;
             }
             this.resolvedEnvironment = resolvedEnvironment;
-            
+
             // console.log("env", environment);
             // console.log("resEnv", resolvedEnvironment);
 
@@ -1333,7 +1333,7 @@
 
         p.startAuthCapture = function(data) {
             var self = this;
-            
+
             var deviceDataValue;
             var nonceValue;
             if (this.myGateway.usePaypal && !this.transaction.state.cardDetails) {
@@ -1345,7 +1345,7 @@
                 // check for a nonce
                 var $paypalSelector = $(this.myGateway.paypalButtonSelector);
                 var nonceSelector = $paypalSelector.find("input[name='payment_method_nonce']");
-                
+
                 nonceValue = nonceSelector.val();
                 if (nonceValue) {
                     //this.gatewayResponseHandler(null, nonceValue);
@@ -1359,7 +1359,7 @@
                 for (var i in TheClass.mappingsProgrammatic) {
                     var mapping = TheClass.mappingsProgrammatic[i];
                     var valueFromForm = this.transaction.state.cardDetails[i];
-                    
+
                     if (valueFromForm) {
                         tokenInfo[TheClass.mappingsProgrammatic[i]] = valueFromForm;
                     }
@@ -1368,7 +1368,7 @@
                 for (var i in TheClass.mappings) {
                     var mapping = TheClass.mappings[i];
                     var valueFromForm = this.transaction.bfjs.core.getFormValue(i, this.transaction.state.$formElement);
-                    
+
                     if (valueFromForm) {
                         tokenInfo[TheClass.mappingsProgrammatic[i]] = valueFromForm;
                     }
@@ -1418,14 +1418,14 @@
                     "paymentMethodNonce": nonce,
                     "accountID": this.transaction.accountID
                 };
-                
+
                 if (deviceData) {
                     payload.deviceData = deviceData;
                 }
 
                 // add BF-only attributes here
                 var additional = {};
-            
+
                 for (var i in TheClass.bfBypass) {
                     var mapping = TheClass.bfBypass[i];
                     var valueFromForm;
@@ -1440,7 +1440,7 @@
                             valueFromForm = valueFromForm && valueFromForm !== "false" ? true : false;
                             break;
                     }
-                    
+
                     if (valueFromForm) {
                         additional[TheClass.bfBypass[i]] = valueFromForm;
                     }
@@ -1496,7 +1496,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -1530,7 +1530,7 @@
                 spreedlyEnvKey = data.results[0].publicKey;
                 if (!data.results[0].publicKey) {
                     failed = true;
-                }   
+                }
             } catch (e){
                 failed = true;
             }
@@ -1542,9 +1542,9 @@
                     detailObj: data
                 });
             }
-            
+
             var tokenInfo = {};
-            
+
             /*for (var i in TheClass.mappings) {
                 var mapping = TheClass.mappings[i];
                 var valueFromForm;
@@ -1553,7 +1553,7 @@
                 } else {
                     valueFromForm = this.transaction.bfjs.core.getFormValue(i, this.transaction.state.$formElement);
                 }
-                
+
                 if (valueFromForm) {
                     switch (mapping) {
                         case 'exp_date':
@@ -1615,7 +1615,7 @@
             var setKeyToVal = function(key, value) {
                 tokenInfo[TheClass.mappings[key]] = value;
             };
-            
+
             for (var i in TheClass.mappings) {
                 var mapping = TheClass.mappings[i];
                 var valueFromForm = resolvedValues[i];
@@ -1623,7 +1623,7 @@
                 var doDefault = function() {
                     setKeyToVal(i, valueFromForm);
                 };
-                
+
                 if (valueFromForm) {
                     switch (i) {
                         case 'exp-date':
@@ -1724,7 +1724,7 @@
 
                 // add BF-only attributes here
                 var additional = {};
-            
+
                 for (var i in TheClass.bfBypass) {
                     var mapping = TheClass.bfBypass[i];
                     var valueFromForm;
@@ -1739,7 +1739,7 @@
                             valueFromForm = valueFromForm && valueFromForm !== "false" ? true : false;
                             break;
                     }
-                    
+
                     if (valueFromForm) {
                         additional[TheClass.bfBypass[i]] = valueFromForm;
                     }
@@ -1788,7 +1788,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -1880,8 +1880,8 @@
             // };
 
             /*var windowProxy;
-            window.onload=function(){ 
-                // Create a proxy window to send to and receive 
+            window.onload=function(){
+                // Create a proxy window to send to and receive
                 // messages from the iFrame
                 windowProxy = new Porthole.WindowProxy(
                     'http://other-domain.com/proxy.html', 'guestFrame');
@@ -2003,7 +2003,7 @@
                     $.extend(lateCardDetails, self.myGateway.getDeferredCardDetails());
                 }
                 var extendedDetails = $.extend(self.transaction.state.cardDetails, lateCardDetails);
-            
+
                 for (var i in TheClass.bfBypass) {
                     var mapping = TheClass.bfBypass[i];
                     var valueFromForm;
@@ -2014,7 +2014,7 @@
                         valueFromForm = valueFromForm && valueFromForm !== "false" ? true : false;
                         break;
                     }
-                    
+
                     if (valueFromForm) {
                         additional[TheClass.bfBypass[i]] = valueFromForm;
                     }
@@ -2085,7 +2085,7 @@
         TheClass.construct = (function() {
             // factory pattern for invoking own constructor with arguments
             // basically: return new this(arguments)
-            
+
             function lambda(args) {
                 return TheClass.apply(this, args);
             }
@@ -2171,8 +2171,8 @@
             // };
 
             /*var windowProxy;
-            window.onload=function(){ 
-                // Create a proxy window to send to and receive 
+            window.onload=function(){
+                // Create a proxy window to send to and receive
                 // messages from the iFrame
                 windowProxy = new Porthole.WindowProxy(
                     'http://other-domain.com/proxy.html', 'guestFrame');
@@ -2379,7 +2379,7 @@
                 TheClass.construct = (function() {
                     // factory pattern for invoking own constructor with arguments
                     // basically: return new this(arguments)
-                    
+
                     function lambda(args) {
                         return TheClass.apply(this, args);
                     }
@@ -2460,7 +2460,7 @@
                     $.extend(lateCardDetails, self.myGateway.getDeferredCardDetails());
                 }
                 var extendedDetails = $.extend(self.transaction.state.cardDetails, lateCardDetails);
-            
+
                 for (var i in TheClass.bfBypass) {
                     var mapping = TheClass.bfBypass[i];
                     var valueFromForm;
@@ -2471,7 +2471,7 @@
                         valueFromForm = valueFromForm && valueFromForm !== "false" ? true : false;
                         break;
                     }
-                    
+
                     if (valueFromForm) {
                         additional[TheClass.bfBypass[i]] = valueFromForm;
                     }
@@ -2600,9 +2600,9 @@
             if (!actor.loadMe) {
                 continue;
             }
-            
+
             var loadedCallback = actor.loadedCallback;
-            
+
             switch (actor.depName) {
                 // case 'Stripe':
                     // stripeActor = bfjs.lateActors[i];
@@ -2617,7 +2617,7 @@
                         actor.loadedCallback = function() {
                             // we allow Braintree to call its own loaded callback only once BraintreeData is in.
                             var url = "https://js.braintreegateway.com/v1/braintree-data.js";
-                            
+
                             // tag load BraintreeData
                             bfjs.loadScript(url, originalLoadedCallback, actor);
                         };
@@ -2639,7 +2639,7 @@
                             callback: loadedCallback
                         });
                     }
-            }            
+            }
         }
 
         for (var i = 0; i<queue.length; i++) {
@@ -2675,14 +2675,14 @@
         document.getElementsByTagName("head")[0].appendChild(script);
     };
 
-    bfjs.core.getFormInput = function(key, $formElement) {        
+    bfjs.core.getFormInput = function(key, $formElement) {
         return $formElement.find("input[bf-data='"+key+"'], select[bf-data='"+key+"']");
     };
 
-    bfjs.core.valueFromFormInput = function($formInput) {        
+    bfjs.core.valueFromFormInput = function($formInput) {
         return $formInput.val();
     };
-    
+
     bfjs.core.getFormValue = function(key, $formElement) {
         var $input = bfjs.core.getFormInput(key, $formElement);
         var value = bfjs.core.valueFromFormInput($input);
@@ -2727,7 +2727,7 @@
         var newTransaction = cardDetails
         ? bfjs.Transaction.construct(bfjs, resolvedGateway, null, accountID, callback, cardDetails)
         : bfjs.Transaction.construct(bfjs, resolvedGateway, formElementSelector, accountID, callback, null);
-        
+
         bfjs.core.doWhenReady(newTransaction);
     };
 
@@ -2794,7 +2794,7 @@
          - Tip: To check for a range of IE versions, use if (!IE || IE < MAX_VERSION)...
         */
 
-        var IE = (function() { 
+        var IE = (function() {
             if (document.documentMode) {
                 return document.documentMode;
             } else {
@@ -2868,11 +2868,19 @@
                     throw "'"+gateway+"' is not the name of any supported gateway."
             }
         }
-        
+
         if (bfjs.core.gatewayChosen){
             bfjs.grabScripts();
         }
     };
 
-    window.BillForward = window.BillForward || bfjs;
+    if (typeof define === 'function' && define.amd) {
+        define([], function() {
+            return bfjs;
+        });
+    } else if (typeof exports !== 'undefined') {
+        module.exports = bfjs;
+    } else {
+        window.BillForward = window.BillForward || bfjs;
+    }
 })();


### PR DESCRIPTION
This PR introduces the [Universal Module Definition](https://github.com/umdjs/umd) (UMD) which makes the library compatible with several types of modules loaders.

Require.js:

``` js
define(['billforward-js'], function(BillForward)  {
  // ...
});
```

Common.js:

``` js
var BillForward = require('billforward-js');
```

Globals:

``` html
<script src="billforward.js"></script>
<script>window.BillForward</script>
```

The UMD is used by tons of tools:
- [Backbone](https://github.com/jashkenas/backbone/blob/master/backbone.js#L8-L34)
- [Lodash](https://github.com/lodash/lodash/blob/master/lodash.js#L14048-L14069)
- [jQuery](https://github.com/jquery/jquery/blob/master/src/intro.js#L15-L38)

---

Technically this is a breaking change on npm because the interface has changed:

Before:

``` js
require('billforward-js');
global.BillForward
```

After:

``` js
var BillForward = require('billforward-js');
```

So please remember to bump this a major version:

``` js
npm version major
npm publish
git push origin master --follow-tags
```

---

(Sorry about the whitespace removals in the diff, my editor just does that, the change is at the very bottom)
