### PR TITLE
rename bf-data to data-bf

### DIFF
--- a/src/billforward.js
+++ b/src/billforward.js
@@ -3098,7 +3098,7 @@
     };
 
     bfjs.core.getFormInput = function(key, $formElement) {
-        return $formElement.find("input[bf-data='"+key+"'], select[bf-data='"+key+"']");
+        return $formElement.find("input[data-bf='"+key+"'], select[data-bf='"+key+"']");
     };
 
     bfjs.core.valueFromFormInput = function($formInput) {


### PR DESCRIPTION
Custom attributes must start with `data-` in order to conform to  the [HTML spec](https://html.spec.whatwg.org/multipage/dom.html#semantics-2:other-applicable-specifications). This PR renames the `bf-data` attribute to `data-bf` in order to conform to the spec. This will be a breaking change.

Fixes #11 