### PR TITLE
Specify email token during payment capture, if present

### DIFF
--- a/src/billforward.js
+++ b/src/billforward.js
@@ -1010,6 +1010,11 @@
                 payload.organizationID = this.transaction.bfjs.state.api.organizationID;
             }
 
+            const cardDetails = this.transaction?.state?.cardDetails;
+            if (cardDetails && cardDetails['email-tokenization-id']) {
+                payload.emailTokenizationID = cardDetails['email-tokenization-id'];
+            }
+
             this.preAuthRequestPayload = payload;
 
             // ready to do pageLoadDo
@@ -3383,11 +3388,15 @@
         return invoke(null, bankAccountDetails, targetGateway, accountID, callback);
     };
 
+    bfjs.setOrgId = function(organizationID) {
+        bfjs.state.api.organizationID = organizationID;
+    }
+
     bfjs.useAPI = function(url, token, organizationID) {
         bfjs.state.api.url = url;
         bfjs.state.api.token = token;
-        bfjs.state.api.organizationID = organizationID;
         bfjs.core.hasBfCredentials = true;
+        bfjs.setOrgId(organizationID);
     };
 
     /**


### PR DESCRIPTION
Supply the payment method request token during pre-auth, if known.

The request token will be used by BF to determine the relevant org. If the public token is only associated with one org, the request token need not be provided (but bfjs will still supply it, if known).